### PR TITLE
Configure Build for Mockito Javaagent Instrumentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
 		<url/>
 	</scm>
 	<properties>
+		<!--    for maven failsafe / surefire-->
+		<argLine/>
 		<java.version>21</java.version>
 	</properties>
 	<dependencies>
@@ -43,7 +45,40 @@
 	</dependencies>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<executions>
+						<execution>
+							<goals>
+								<goal>properties</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<configuration>
+						<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-failsafe-plugin</artifactId>
+					<configuration>
+						<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>


### PR DESCRIPTION
Configure maven dependency, failsafe and surefire plugin to add `mockito-core` as a javaagent.